### PR TITLE
Removed ntp install. Not required as Centos has chrony already enabled

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -3,11 +3,3 @@
 sudo yum install -y deltarpm
 
 sudo yum -y update
-
-
-# Install NTP Services so our system time is always in sync
-sudo yum install -y ntp ntpdate ntp-doc
-sudo service ntpd stop # Just to make sure
-sudo chkconfig ntpd on
-sudo ntpdate pool.ntp.org
-sudo service ntpd start


### PR DESCRIPTION
https://www.thegeekdiary.com/centos-rhel-7-chrony-vs-ntp-differences-between-ntpd-and-chronyd/