### PR TITLE
Fix for Pip issues in the linux builds

### DIFF
--- a/scripts/alfresco.sh
+++ b/scripts/alfresco.sh
@@ -3,6 +3,6 @@
 set -e
 
 sudo yum install -y git
-sudo easy_install pip
+sudo easy_install pip==20.3.4
 sudo pip install ansible==2.6 boto3 botocore boto
 

--- a/scripts/ansible_galaxy_base.sh
+++ b/scripts/ansible_galaxy_base.sh
@@ -6,6 +6,6 @@ sudo yum install -y \
     wget \
     yum-utils
 
-sudo easy_install pip
+sudo easy_install pip==20.3.4
 
 sudo pip install ansible==2.6 virtualenv awscli boto botocore boto3 shyaml


### PR DESCRIPTION
The latest version of PIp is no longer compatible with Python 2.7. Set to install last version compatible pip==20.3.4