### PR TITLE
Revert to use AWS windows 2019 base ami

### DIFF
--- a/windows_cporacle_appserver.json
+++ b/windows_cporacle_appserver.json
@@ -33,16 +33,12 @@
       "user_data_file": "scripts/Windows/Base/ConfigureWinRM2019.txt",
       "source_ami_filter": {
         "filters": {
-          "virtualization-type": "hvm",
-          "architecture": "x86_64",
-          "name": "HMPPS Windows Server Base 2019 {{user `branch_name`}}*",
-          "root-device-type": "ebs"
+          "name": "Windows_Server-2019-English-Full-Base-*",
+          "most_recent": true,
+          "owners": [
+            "amazon"
+          ]
         },
-        "owners": [
-          "895523100917"
-        ],
-        "most_recent": true
-      },
       "instance_type": "t3.xlarge",
       "ami_users": [
         "964150688482",
@@ -73,8 +69,12 @@
   ],
   "provisioners": [
     {
+      "type": "windows-shell",
+      "inline": ["mkdir c:\\temp"]
+    },
+    {
       "type": "powershell",
-      "script": "scripts/Windows/All/MakeTemp.ps1"
+      "script": "scripts/Windows/Base/DisableSpoolerService.ps1"
     },
     {
       "type": "powershell",


### PR DESCRIPTION
Some discrepancies where CPOracle differs from MIS and JENKINS builds remain such as admin passwords. Which need to be resolved in order to use the base pipeline base AMI correctly.